### PR TITLE
Only use .Site.Title if ne .Title

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,6 +1,9 @@
 {{ partial "doctype.html" . }}
 <head>
-  <title> {{ .Title }} // {{ .Site.Title }} </title>
+  <title>
+    {{ .Title }}{{ if ne .Title .Site.Title }} // {{ .Site.Title }}{{ end }}
+  </title>
+
   {{ partial "meta.html" . }}
 
   {{ partial "og.html" . }}


### PR DESCRIPTION
- The `.Title` of `.Site.BaseUrl` is the same as `.Site.Title`.
