### PR TITLE
Use .Site.Title and .Site.Params.description…

### DIFF
--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -2,8 +2,18 @@
   <div class="header">
     {{ partial "sidebarheader.html" . }}
 
-    {{ if .Site.Params.sidebartitle }}<h1 class="brand-title">{{ .Site.Params.sidebartitle }}</h1>{{ end }}
-    {{ if .Site.Params.sidebartagline }}<h2 class="brand-tagline">{{ .Site.Params.sidebartagline }}</h2>{{ end }}
+    <h1 class="brand-title">
+      {{ if .Site.Params.sidebartitle }}
+        {{ .Site.Params.sidebartitle }}
+      {{ else }}
+        {{ .Site.Title }}
+      {{ end }}
+    </h1>
+    {{ if .Site.Params.sidebartagline }}
+      <h2 class="brand-tagline">{{ .Site.Params.sidebartagline }}</h2>
+    {{ else if .Site.Params.description }}
+      <h2 class="brand-tagline"> {{ .Site.Params.description }}</h2>
+    {{ end }}
 
     <nav class="nav">
       <ul class="nav-list">


### PR DESCRIPTION
…if `.Site.Params.sidebartitle` and `.Site.Params.sidebartagline` are not set.

This makes it so that `h1#brand-title` is always visible.
