### PR TITLE
Fix category link on homepage when hugo site is not at the root of the domain

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -8,6 +8,7 @@
             {{ partial "listtop.html" . }}
 
           <div class="posts">
+            {{ $Site := .Site }}
             {{ range .Site.Recent }}
             <section  class="post">
                 <header class="post-header">
@@ -35,7 +36,7 @@
                 {{ if .Params.categories }}
                 <div class="post-categories">
                     {{ range .Params.categories }}
-                    <a class="post-category post-category-{{ . | urlize }}" href="/categories/{{ . | urlize }}">{{ . }}</a> 
+                    <a class="post-category post-category-{{ . | urlize }}" href="{{ $Site.BaseUrl }}/categories/{{ . | urlize }}">{{ . }}</a>
                     {{ end }}
                 </div>
                 {{ end }}


### PR DESCRIPTION
The category link on homepage assumes the site is at the root of the domain. This patch fixes the issue and uses .Site.BaseUrl to point to the right path.
