### PR TITLE
fix pathing for sites that have http and https enabled at the same time

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -21,7 +21,7 @@
     <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7/html5shiv.js"></script>
   <![endif]-->
 
-  <link rel="stylesheet" href="{{ .Site.BaseUrl }}/css/redlounge.css">
+  <link rel="stylesheet" href="/css/redlounge.css">
   <link href="//maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css" rel="stylesheet">
   <link href='//fonts.googleapis.com/css?family=Raleway:400,200,100,700,300,500,600,800' rel='stylesheet' type='text/css'>
   <link href='//fonts.googleapis.com/css?family=Libre+Baskerville:400,700,400italic' rel='stylesheet' type='text/css'>
@@ -37,8 +37,8 @@
 
   {{ if .Params.lightbox }}
   <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
-  <link rel="stylesheet" type="text/css" href="{{ .Site.BaseUrl }}/css/lightbox.css">
-  <script src="{{ .Site.BaseUrl }}/js/lightbox.min.js"></script>
+  <link rel="stylesheet" type="text/css" href="/css/lightbox.css">
+  <script src="/js/lightbox.min.js"></script>
   {{ end }}
 
   {{ if .Site.Params.categoriescss }}


### PR DESCRIPTION
**_Love your theme**_
I ran into a small issue on my site because it uses http and https but the base url is http. By changing the paths to not include the base url param everything works correctly in both.

[http](http://vrecan.github.io/) & [https](https://vrecan.github.io/)

Without this change I would get mixed content errors in chrome and all css would fail to load.
