### PR TITLE
Allow HTML tags in footer copyright notice

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -8,5 +8,5 @@
 		</ul>
 	</div>
 
-	<p>{{ with .Site.Params.Copyright }}{{.}}{{ else }}&copy; {{.Now.Format "2006"}}. All rights reserved. {{end}}</p>
+	<p>{{ with .Site.Params.Copyright }}{{ . | safeHTML }}{{ else }}&copy; {{.Now.Format "2006"}}. All rights reserved.{{end}}</p>
 </div>


### PR DESCRIPTION
Hello!

I think that allowing HTML tags in the footer copyright notice would be neat, as it would allow hyperlinks and images to be used, e.g. in the Creative Commons License template:

```
[params]
    Copyright = '<a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a><br />This <span xmlns:dct="http://purl.org/dc/terms/" href="http://purl.org/dc/dcmitype/Text" rel="dct:type">work</span> is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.'
```

This Pull Request uses `safeHTML` to allow for that possibility.

Thanks!

Cheers,
Anthony