### PR TITLE
Add meta generator tag to show Hugo and version

### DIFF
--- a/layouts/partials/meta.html
+++ b/layouts/partials/meta.html
@@ -7,3 +7,4 @@
 <meta name="description" content="{{ .Description }}">
 <meta name="keywords" content="{{ range .Keywords }}{{ . }},{{ end }}">
 <meta name="author" content="{{ .Params.author }}">
+{{ .Hugo.Generator }}


### PR DESCRIPTION
Hello!

I suggest adding the meta generator tag like so:

```html
<meta name="generator" content="Hugo 0.15-DEV" />
```

with the use of `{{ .Hugo.Generator }}` which was first made available in Hugo 0.13.

Of course, this is entirely optional, but I think it would help promote Hugo.  :-)

Cheers,
Anthony