### PR TITLE
Add `min_version = 0.14` to config.toml

### DIFF
--- a/theme.toml
+++ b/theme.toml
@@ -5,6 +5,8 @@ licenselink = "https://github.com/tmaiaroto/hugo-redlounge/blob/master/LICENSE.m
 source_repo = "http://github.com/tmaiaroto/hugo-redlounge"
 tags = ["redlounge", "red", "raleway", "libre baskerville", "blog", "gallery"]
 features = ["blog", "gallery"]
+min_version = 0.14
+
 [author]
     name = "Tom Maiaroto"
     homepage = "http://www.shift8creative.com"


### PR DESCRIPTION
This is to ensure users using an outdated version like Hugo 0.12 would know that they need to upgrade their copy of Hugo to work with the latest and greatest redlounge theme.  :-)