### PR TITLE
Update to use highlight.js 8.7.

### DIFF
--- a/layouts/partials/syntaxhighlight.html
+++ b/layouts/partials/syntaxhighlight.html
@@ -1,8 +1,8 @@
   <!-- Syntax highlighting -->
   {{ if isset .Site.Params "highlightStyle" }}
-  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/{{ .Site.Params.highlightStyle }}.min.css">
+  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.7/styles/{{ .Site.Params.highlightStyle }}.min.css">
   {{ else }}
-  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/tomorrow-night-bright.min.css">
+  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.7/styles/tomorrow-night-bright.min.css">
   {{ end }}
-  <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
+  <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.7/highlight.min.js"></script>
   <script>hljs.initHighlightingOnLoad();</script>


### PR DESCRIPTION
Some useful syntax styles and languages have been added since 8.4, so an
update seems appropriate.