### PR TITLE
Enable sidebar photo to be responsive on mobile device

### DIFF
--- a/static/css/redlounge.css
+++ b/static/css/redlounge.css
@@ -451,6 +451,14 @@ hr.thin {
 	h2.brand-tagline {
 		font-size: 1.2rem;
 	}
+
+	.header>.sidebarphoto{
+	    width:160px;
+	    height:160px;
+	    border-radius: 50%;
+	    -moz-border-radius: 50%;
+	    -webkit-border-radius: 50%;
+	}
 }
 
 @media (min-width: 48rem) {
@@ -468,7 +476,7 @@ hr.thin {
         text-align: right;
     }
 
-    .header .sidebarphoto{
+    .header>.sidebarphoto{
 	    width:160px;
 	    height:160px;
 	    border-radius: 50%;


### PR DESCRIPTION
After testing it on my android mobile phone and chrome mobile simulator,I updated the style to make the sidebar photo can also works fine on a mobile device.