### PR TITLE
Fix margin space of table element

### DIFF
--- a/static/css/redlounge.css
+++ b/static/css/redlounge.css
@@ -401,6 +401,9 @@ a.post-category:hover {
 nav#TableOfContents li {
 	padding-bottom: 0.25rem;
 }
+nav#TableOfContents ul:first-child {
+    padding-left: 0px;
+}
 .toc-label {
 	font-size: 0.8rem;
 	color: #aeaeae;

--- a/static/css/redlounge.css
+++ b/static/css/redlounge.css
@@ -218,6 +218,10 @@ a.post-author {
 	font-weight: 200;
 	color: #999;
 }
+.post table {
+    margin-bottom: 1.75rem;
+    margin-top: 0;
+}
 .post-title {
     font-size: 2rem;
     color: #222;


### PR DESCRIPTION
![screen shot 2016-09-12 at 4 53 28 pm](https://cloud.githubusercontent.com/assets/1492050/18431466/8f1637da-790f-11e6-93b5-47a0858aae75.png)

I think `<table>` can share the same `margin-bottom` value with `<p>`.