### PR TITLE
only display '/Read More...' link if post is truncated

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -41,12 +41,16 @@
       					</div>
       				{{ end }}
             </p>
-            <article class="post-summary">
+            {{ if .Truncated  }}
+              <article class="post-summary">
             	{{ .Summary }}
-            </article>
-			<div class="read-more-link">
+              </article>
+			  <div class="read-more-link">
 				<a href="{{ .RelPermalink }}"><span class="read-more-slashes">//</span>Read More...</a>
-			</div>
+			  </div>
+            {{ else }}
+              {{ .Content }}
+            {{ end }}
           </section>
         {{ end }}
       </div>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -41,12 +41,16 @@
                 </div>
                 {{ end }}
             </p>
-            <article class="post-summary">
+            {{ if .Truncated  }}
+              <article class="post-summary">
                   {{ .Summary }}
               </article>
               <div class="read-more-link">
                   <a href="{{ .RelPermalink }}"><span class="read-more-slashes">//</span>Read More...</a>
               </div>
+            {{ else }}
+              {{ .Content }}
+            {{ end }}
           </section>
           {{ end }}
         </div>


### PR DESCRIPTION
The hugo-redlounge theme includes a '/Read More...' link, even on short
posts that are not truncated. This pull request modifies the theme to
exclude the '/Read More...' link when the post is short enough to be
displayed in its entirely (i.e. not truncated).