### PR TITLE
Suggested change to favicon link

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -28,7 +28,7 @@
 
   <!-- Icons -->
   <link rel="apple-touch-icon-precomposed" sizes="144x144" href="/touch-icon-144-precomposed.png">
-  <link rel="shortcut icon" href="/favicon.png">
+  <link rel="shortcut icon" type="image/x-icon" href="/img/favicon.png">
 
   <!-- RSS -->
   <link href="{{ .RSSlink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />


### PR DESCRIPTION
I moved the link to point at the img subdirectory and added the type syntax the link. This will bring the favicon up everytime and avoid issues where the browser caches the icon.