### PR TITLE
Rename RSSlink to RSSLink

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -31,7 +31,7 @@
   <link rel="shortcut icon" type="image/x-icon" href="/img/favicon.png">
 
   <!-- RSS -->
-  <link href="{{ .RSSlink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
+  <link href="{{ .RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
 
   {{ partial "syntaxhighlight.html" . }}
 


### PR DESCRIPTION
The former will be deprecated and eventually removed from Hugo.

Note: Currently both of them exist in Hugo, which is the reason for the cleanup.