### PR TITLE
Page's Now is deprecated. Use now instead.

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -8,5 +8,5 @@
 		</ul>
 	</div>
 
-	<p>{{ with .Site.Params.Copyright }}{{ . | safeHTML }}{{ else }}&copy; {{.Now.Format "2006"}}. All rights reserved.{{end}}</p>
+	<p>{{ with .Site.Params.Copyright }}{{ . | safeHTML }}{{ else }}&copy; {{now.Format "2006"}}. All rights reserved.{{end}}</p>
 </div>


### PR DESCRIPTION
Fixed issue #43 