### PR TITLE
RSSLink deprecated, Page .Hugo deprecated, Data.Pages replaced w Site.RegularPages

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -8,7 +8,7 @@
       {{ partial "listtop.html" . }}
 
       <div class="posts">
-        {{ range .Data.Pages }}
+        {{ range .Site.RegularPages }}
           <section  class="post">
             <header class="post-header">
             {{ if .Params.thumbnail }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -9,7 +9,7 @@
 
           <div class="posts">
             {{ $Site := .Site }}
-            {{ range .Data.Pages }}
+            {{ range .Site.RegularPages }}
             <section  class="post">
                 <header class="post-header">
                     {{ if .Params.thumbnail }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -31,7 +31,7 @@
   <link rel="shortcut icon" type="image/x-icon" href="/img/favicon.png">
 
   <!-- RSS -->
-  <link href="{{ .RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
+  <link href="{{ with .OutputFormats.Get "RSS" }} {{ .RelPermalink }} {{ end }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
 
   {{ partial "syntaxhighlight.html" . }}
 

--- a/layouts/partials/meta.html
+++ b/layouts/partials/meta.html
@@ -7,4 +7,4 @@
 <meta name="description" content="{{ .Description }}">
 <meta name="keywords" content="{{ range .Keywords }}{{ . }},{{ end }}">
 <meta name="author" content="{{ .Params.author }}">
-{{ .Hugo.Generator }}
+{{ hugo.Generator }}


### PR DESCRIPTION
RSSLink and Page's .Hugo deprecation warnings started with v0.55 
Empty homepage for post list started with v0.58 : replacing `Data.Pages` with `Site.RegularPages` takes care of this issue